### PR TITLE
Feature/systemd autostart

### DIFF
--- a/Service/README.md
+++ b/Service/README.md
@@ -6,11 +6,14 @@ Credit of Leigh Dastey (ldastey@outlook.com).
 
 ## SystemD Configuration
 
-1. sudo ln -s *$INSTALL_DIR*/Service/smart-car-server.service /lib/systemd/system/smart-car-server.service  
-2. sudo ln -s *$INSTALL_DIR*/Service/smart-car-server /etc/init.d/smart-car-server
-3. sudo systemctl daemon-reload
-4. sudo systemctl enable smart-car-server
-5. sudo reboot
+*INSTALL_DIR below should be replaced throughout to the path of the file on your system*
+
+1. Edit *$INSTALL_DIR*/Service/smart-car-server /etc/init.d/smart-car-server and modify $$INSTALL_DIR$$ to be the path of this file on your system
+2. sudo ln -s *$INSTALL_DIR*/Service/smart-car-server.service /lib/systemd/system/smart-car-server.service  
+3. sudo ln -s *$INSTALL_DIR*/Service/smart-car-server /etc/init.d/smart-car-server
+4. sudo systemctl daemon-reload
+5. sudo systemctl enable smart-car-server
+6. sudo reboot
 
 When the Pi restarts you will be able to connect client applications (i.e. mobile app) and test you can connect.
 

--- a/Service/README.md
+++ b/Service/README.md
@@ -1,0 +1,20 @@
+# Autostart
+
+To enable the Freenove Smart Car Server to run at startup follow the steps for your distro.
+
+Credit of Leigh Dastey (ldastey@outlook.com).
+
+## SystemD Configuration
+
+1. sudo ln -s *$INSTALL_DIR*/Service/smart-car-server.service /lib/systemd/system/smart-car-server.service  
+2. sudo ln -s *$INSTALL_DIR*/Service/smart-car-server /etc/init.d/smart-car-server
+3. sudo systemctl daemon-reload
+4. sudo systemctl enable smart-car-server
+5. sudo reboot
+
+When the Pi restarts you will be able to connect client applications (i.e. mobile app) and test you can connect.
+
+### SystemD Disable Autostart
+
+1. sudo systemctl disable smart-car-server
+

--- a/Service/smart-car-server
+++ b/Service/smart-car-server
@@ -13,5 +13,5 @@
 # Short-Description: Pi Smart Car Server
 ### END INIT INFO
 
-sudo /usr/bin/python /home/pi/Projects/pi-smart-car/Code/Server/main.py -t -n
+sudo /usr/bin/python $$INSTALL_DIR$$/Code/Server/main.py -t -n
  

--- a/Service/smart-car-server
+++ b/Service/smart-car-server
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#
+# Copy this file to /etc/init.d/
+#
+
+### BEGIN INIT INFO
+# Provides:          smart-car-server
+# Required-Start:    $all
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Pi Smart Car Server
+### END INIT INFO
+
+sudo /usr/bin/python /home/pi/Projects/pi-smart-car/Code/Server/main.py -t -n
+ 

--- a/Service/smart-car-server.service
+++ b/Service/smart-car-server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pi Smart Car Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sleep 20
+ExecStart=/bin/bash /etc/init.d/smart-car-server
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The autostart instructions in the existing guide don't work well (if at all). This is a more standard and secure way to enable autostart of the smart car server using SystemD service manager.